### PR TITLE
Parse environment selection from kubeforward config

### DIFF
--- a/cmd/kubeforward/main.go
+++ b/cmd/kubeforward/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+
+	"gopkg.in/yaml.v3"
 )
 
 const defaultVersion = "0.0.0"
@@ -12,21 +14,27 @@ const defaultVersion = "0.0.0"
 var version = defaultVersion
 
 type forwardRequest struct {
-	configPath string
+	configPath  string
+	environment string
 }
 
-func parseArgs() forwardRequest {
+func newFlagSet() (*flag.FlagSet, *string, *bool) {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	configPath := fs.String("f", "kubeforward.yml", "Path to configuration file")
 	showVersion := fs.Bool("version", false, "Print version and exit")
 
 	fs.Usage = func() {
 		fmt.Fprintf(fs.Output(), "kubeforward - forward Kubernetes resources based on a config file.\n\n")
-		fmt.Fprintf(fs.Output(), "Usage:\n  kubeforward [flags]\n\n")
+		fmt.Fprintf(fs.Output(), "Usage:\n  kubeforward [flags] <environment>\n\n")
 		fmt.Fprintf(fs.Output(), "Flags:\n")
 		fs.PrintDefaults()
 	}
 
+	return fs, configPath, showVersion
+}
+
+func parseArgs() forwardRequest {
+	fs, configPath, showVersion := newFlagSet()
 	_ = fs.Parse(os.Args[1:])
 
 	if *showVersion {
@@ -35,14 +43,23 @@ func parseArgs() forwardRequest {
 	}
 
 	if len(fs.Args()) > 0 {
-		fmt.Fprintln(fs.Output(), "error: unexpected arguments")
-		fs.Usage()
-		os.Exit(2)
+		if len(fs.Args()) > 1 {
+			fmt.Fprintln(fs.Output(), "error: too many arguments")
+			fs.Usage()
+			os.Exit(2)
+		}
 	}
 
 	return forwardRequest{
-		configPath: *configPath,
+		configPath:  *configPath,
+		environment: fs.Arg(0),
 	}
+}
+
+func printUsage() {
+	fs, _, _ := newFlagSet()
+	fs.SetOutput(os.Stderr)
+	fs.Usage()
 }
 
 func resolvedVersion() string {
@@ -58,6 +75,30 @@ func resolvedVersion() string {
 	return info.Main.Version
 }
 
+type config struct {
+	Environments map[string]environment `yaml:"environments"`
+}
+
+type environment struct {
+	Context    string               `yaml:"context"`
+	Namespaces map[string]namespace `yaml:"namespaces"`
+}
+
+type namespace struct {
+	Forwards []forward `yaml:"forwards"`
+}
+
+type forward struct {
+	Kind  string `yaml:"kind"`
+	Name  string `yaml:"name"`
+	Ports []port `yaml:"ports"`
+}
+
+type port struct {
+	LocalPort  int `yaml:"localPort"`
+	RemotePort int `yaml:"remotePort"`
+}
+
 func main() {
 	request := parseArgs()
 	configData, err := os.ReadFile(request.configPath)
@@ -66,5 +107,30 @@ func main() {
 		os.Exit(1)
 	}
 
+	var cfg config
+	if err := yaml.Unmarshal(configData, &cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "error: unable to parse config %q: %v\n", request.configPath, err)
+		os.Exit(1)
+	}
+
+	if len(cfg.Environments) == 0 {
+		fmt.Fprintf(os.Stderr, "error: config %q has no environments defined\n", request.configPath)
+		os.Exit(1)
+	}
+
+	if request.environment == "" {
+		fmt.Fprintln(os.Stderr, "error: missing environment argument")
+		fmt.Fprintln(os.Stderr)
+		printUsage()
+		os.Exit(2)
+	}
+
+	selected, ok := cfg.Environments[request.environment]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "error: environment %q not found in config\n", request.environment)
+		os.Exit(1)
+	}
+
 	fmt.Printf("Loaded config from %s (%d bytes)\n", request.configPath, len(configData))
+	fmt.Printf("Selected environment %s (context %s)\n", request.environment, selected.Context)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module kubeforward
 
 go 1.22
+
+require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/kubeforward.yml
+++ b/kubeforward.yml
@@ -1,0 +1,54 @@
+environments:
+  dev:
+    context: dev-cluster
+    namespaces:
+      platform:
+        forwards:
+          - kind: service
+            name: api-service
+            ports:
+              - localPort: 8080
+                remotePort: 80
+          - kind: deployment
+            name: web
+            ports:
+              - localPort: 3000
+                remotePort: 3000
+      data:
+        forwards:
+          - kind: service
+            name: neo4j
+            ports:
+              - localPort: 7474
+                remotePort: 7474
+              - localPort: 7687
+                remotePort: 7687
+  prod:
+    context: prod-cluster
+    namespaces:
+      platform:
+        forwards:
+          - kind: service
+            name: api-service
+            ports:
+              - localPort: 8081
+                remotePort: 80
+          - kind: deployment
+            name: web
+            ports:
+              - localPort: 3001
+                remotePort: 3000
+      data:
+        forwards:
+          - kind: pod
+            name: worker-0
+            ports:
+              - localPort: 9000
+                remotePort: 9000
+          - kind: service
+            name: neo4j
+            ports:
+              - localPort: 7475
+                remotePort: 7474
+              - localPort: 7688
+                remotePort: 7687


### PR DESCRIPTION
### Motivation
- Make the CLI consume the first positional argument as the environment selection so the configuration is unambiguous and the user can select an environment from the `environments` map in the config.

### Description
- Add YAML parsing of `kubeforward.yml` with structs for `config`, `environment`, `namespace`, `forward`, and `port` and select the requested environment by name using the first positional argument. 
- Update CLI parsing to accept a positional `environment` argument, change usage text to `kubeforward [flags] <environment>`, and validate argument count via `newFlagSet`, `parseArgs`, and `printUsage` helpers. 
- Validate that the config contains `environments`, emit clear errors when the environment is missing or not found, and print the selected environment context. 
- Add `gopkg.in/yaml.v3` to `go.mod` and include a sample `kubeforward.yml` to exercise the new parsing behavior. 

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977670285bc832b82314f67d3871cd3)