### PR TITLE
Use vcpkg + cxxopts for robust CLI parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# CMake build artifacts
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(kubeforward VERSION 0.1.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(cxxopts CONFIG REQUIRED)
+
+add_executable(kubeforward src/main.cpp)
+target_link_libraries(kubeforward PRIVATE cxxopts::cxxopts)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: build
+
+build:
+	cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake"
+	cmake --build build

--- a/README.md
+++ b/README.md
@@ -1,19 +1,44 @@
 # kubeforward
 
-CLI to forward kubectl services to local.
+Kubeforward is a C++ CLI project built with CMake and dependencies managed through vcpkg (manifest mode).
 
-## Quick start
+## Requirements
+
+- CMake 3.16+
+- A C++20-compatible compiler
+- vcpkg (set `VCPKG_ROOT`)
+
+## Dependency management (vcpkg)
+
+This repository uses `vcpkg.json` with a pinned `builtin-baseline` to keep dependency resolution reproducible.
+
+## Build
+
+### Using Make (recommended)
 
 ```bash
-go build ./cmd/kubeforward
+VCPKG_ROOT=/path/to/vcpkg make build
 ```
+
+### Using CMake directly
 
 ```bash
-./kubeforward api-service --namespace platform --local-port 8080 --remote-port 80
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+cmake --build build
 ```
 
-## CLI options
+## Usage
 
 ```bash
-./kubeforward --help
+./build/kubeforward -h
+./build/kubeforward --flag1 --flag2 demo
 ```
+
+## Supported flags
+
+- `-h` shows the help message.
+- `--flag1` is a boolean flag and is set to `true` when provided.
+- `--flag2 <value>` accepts a required value.
+
+The CLI prints a summary of parsed flags after execution.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <string>
+
+#include <cxxopts.hpp>
+
+int main(int argc, char* argv[]) {
+  bool show_help = false;
+  bool flag1 = false;
+  std::string flag2;
+
+  cxxopts::Options options("kubeforward", "Kubeforward CLI");
+  options.add_options()("h", "Show help message", cxxopts::value<bool>(show_help)->default_value("false"))(
+      "flag1", "Enable flag1 (boolean)", cxxopts::value<bool>(flag1)->default_value("false")->implicit_value("true"))(
+      "flag2", "Set flag2 value", cxxopts::value<std::string>(flag2));
+
+  try {
+    options.parse_positional({});
+    options.parse(argc, argv);
+  } catch (const cxxopts::exceptions::exception& e) {
+    std::cerr << "Error: " << e.what() << "\n";
+    return 1;
+  }
+
+  if (show_help) {
+    std::cout << options.help() << "\n";
+  }
+
+  std::cout << "Flag summary:\n"
+            << "  help: " << (show_help ? "true" : "false") << "\n"
+            << "  flag1: " << (flag1 ? "true" : "false") << "\n"
+            << "  flag2: " << (flag2.empty() ? "<unset>" : flag2) << "\n";
+
+  return 0;
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "kubeforward",
+  "version-string": "0.1.0",
+  "builtin-baseline": "1940ee77e81573713c0d364c42f5990172198be1",
+  "dependencies": [
+    "cxxopts"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Replace fragile, hand-rolled `argv` parsing with a maintained CLI library to provide deterministic, well-tested flag semantics.
- Ensure dependency management is reproducible by using vcpkg manifest mode with a pinned `builtin-baseline` as required by project conventions.
- Provide a clear, repeatable developer build flow that wires vcpkg into CMake so contributors can build with identical dependencies.

### Description
- Add `vcpkg.json` to pin the vcpkg baseline and declare the `cxxopts` dependency for CLI parsing.
- Update `CMakeLists.txt` to `find_package(cxxopts CONFIG REQUIRED)` and link `cxxopts::cxxopts` to the `kubeforward` target.
- Replace manual parsing in `src/main.cpp` with an implementation that uses `cxxopts` and preserves `-h`, `--flag1`, and `--flag2` semantics and error handling.
- Add a `Makefile` that configures CMake with the vcpkg toolchain via `-DCMAKE_TOOLCHAIN_FILE="$(VCPKG_ROOT)/scripts/buildsystems/vcpkg.cmake"` and update `README.md` and `.gitignore` with vcpkg/CMake build guidance.

### Testing
- Ran `rm -rf build && VCPKG_ROOT=/tmp/vcpkg make build` and vcpkg installed `cxxopts` and the project built successfully (pass).
- Executed `./build/kubeforward -h` and observed help output (pass).
- Executed `./build/kubeforward --flag1 --flag2 abc` and observed expected parsed values (pass).
- Executed `./build/kubeforward --flag2` and observed a deterministic parse error for the missing value (non-zero exit expected and observed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994e40bf474832baf0d4a9fe0edae58)