### PR TITLE
Normalize Linux x64 release artifact name to use amd64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,11 @@ jobs:
         shell: bash
         run: |
           VERSION="${GITHUB_REF_NAME}"
-          PKG_NAME="kubeforward-${VERSION}-${{ matrix.os_name }}-${{ matrix.arch }}"
+          ARCH="${{ matrix.arch }}"
+          if [[ "${{ matrix.os_name }}" == "linux" && "${ARCH}" == "x64" ]]; then
+            ARCH="amd64"
+          fi
+          PKG_NAME="kubeforward-${VERSION}-${{ matrix.os_name }}-${ARCH}"
 
           mkdir -p "dist/${PKG_NAME}"
           cp build/Release/kubeforward "dist/${PKG_NAME}/"


### PR DESCRIPTION
### Motivation
- Normalize release artifact names so Linux x64 builds use `amd64` in the package filename for consistent cross-platform naming.

### Description
- Updated `.github/workflows/release.yml` to introduce an `ARCH` variable derived from `matrix.arch` and map `x64` to `amd64` when `matrix.os_name` is `linux`, and use `ARCH` in the Unix `PKG_NAME` when creating the release bundle.

### Testing
- The release workflow's `Build (Release)` and `Test (Release)` steps run using `cmake` and `ctest` for the x64 matrix entry and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a176757454832bbb35da40f702c5ae)