### PR TITLE
Remove Windows from release workflow for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
             dist/*.tar.gz
             dist/*.tar.gz.sha256
 
-  build-linux-windows-unsigned:
+  build-linux-unsigned:
     strategy:
       fail-fast: false
       matrix:
@@ -150,14 +150,6 @@ jobs:
             os_name: linux
             arch: arm64
             triplet: arm64-linux
-          - runner: windows-latest
-            os_name: windows
-            arch: x64
-            triplet: x64-windows
-          - runner: windows-11-arm
-            os_name: windows
-            arch: arm64
-            triplet: arm64-windows
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
@@ -165,8 +157,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install vcpkg (Unix)
-        if: runner.os != 'Windows'
+      - name: Install vcpkg
         shell: bash
         run: |
           VCPKG_ROOT="${RUNNER_TEMP}/vcpkg"
@@ -176,18 +167,6 @@ jobs:
           git -C "${VCPKG_ROOT}" checkout "${VCPKG_COMMIT}"
           "${VCPKG_ROOT}/bootstrap-vcpkg.sh" -disableMetrics
           echo "VCPKG_ROOT=${VCPKG_ROOT}" >> "${GITHUB_ENV}"
-
-      - name: Install vcpkg (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $vcpkgRoot = Join-Path $env:RUNNER_TEMP 'vcpkg'
-          $vcpkgCommit = (Select-String -Path 'vcpkg.json' -Pattern '"builtin-baseline"').Line.Split('"')[3]
-          git clone --depth 1 https://github.com/microsoft/vcpkg.git $vcpkgRoot
-          git -C $vcpkgRoot fetch --depth 1 origin $vcpkgCommit
-          git -C $vcpkgRoot checkout $vcpkgCommit
-          & "$vcpkgRoot/bootstrap-vcpkg.bat" -disableMetrics
-          "VCPKG_ROOT=$vcpkgRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Build (Release)
         shell: bash
@@ -207,8 +186,7 @@ jobs:
           cmake --build build/Release --config Release --target kubeforward_tests
           ctest --test-dir build/Release --output-on-failure --build-config Release
 
-      - name: Package release bundle (Unix)
-        if: runner.os != 'Windows'
+      - name: Package release bundle
         shell: bash
         run: |
           VERSION="${GITHUB_REF_NAME}"
@@ -225,26 +203,6 @@ jobs:
           tar -C dist -czf "dist/${PKG_NAME}.tar.gz" "${PKG_NAME}"
           shasum -a 256 "dist/${PKG_NAME}.tar.gz" > "dist/${PKG_NAME}.tar.gz.sha256"
 
-      - name: Package release bundle (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $version = $env:GITHUB_REF_NAME
-          $pkgName = "kubeforward-$version-${{ matrix.os_name }}-${{ matrix.arch }}"
-          $pkgDir = Join-Path 'dist' $pkgName
-
-          New-Item -ItemType Directory -Path $pkgDir -Force | Out-Null
-          $binary = Get-ChildItem -Path 'build/Release' -Recurse -Filter 'kubeforward.exe' | Select-Object -First 1 -ExpandProperty FullName
-          if (-not $binary) {
-            throw 'kubeforward.exe not found under build/Release'
-          }
-          Copy-Item $binary -Destination $pkgDir
-          Copy-Item 'README.md' -Destination $pkgDir
-          Copy-Item 'LICENSE' -Destination $pkgDir
-          Compress-Archive -Path $pkgDir -DestinationPath "dist/$pkgName.zip" -Force
-          $hash = (Get-FileHash "dist/$pkgName.zip" -Algorithm SHA256).Hash.ToLowerInvariant()
-          "$hash  $pkgName.zip" | Out-File -FilePath "dist/$pkgName.zip.sha256" -Encoding ascii
-
       - name: Upload unsigned bundle
         uses: actions/upload-artifact@v4
         with:
@@ -252,15 +210,13 @@ jobs:
           path: |
             dist/*.tar.gz
             dist/*.tar.gz.sha256
-            dist/*.zip
-            dist/*.zip.sha256
 
   publish-pre1-release:
     if: startsWith(github.ref_name, '0.')
     runs-on: ubuntu-latest
     needs:
       - build-macos-unsigned
-      - build-linux-windows-unsigned
+      - build-linux-unsigned
     steps:
       - name: Download all unsigned bundles
         uses: actions/download-artifact@v4
@@ -277,8 +233,6 @@ jobs:
           files: |
             dist/*.tar.gz
             dist/*.tar.gz.sha256
-            dist/*.zip
-            dist/*.zip.sha256
 
   sign-notarize-release:
     if: ${{ !startsWith(github.ref_name, '0.') }}
@@ -371,7 +325,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - sign-notarize-release
-      - build-linux-windows-unsigned
+      - build-linux-unsigned
     steps:
       - name: Download signed macOS bundle
         uses: actions/download-artifact@v4
@@ -386,13 +340,6 @@ jobs:
           pattern: kubeforward-linux-*-unsigned
           merge-multiple: true
 
-      - name: Download Windows unsigned bundles
-        uses: actions/download-artifact@v4
-        with:
-          path: dist
-          pattern: kubeforward-windows-*-unsigned
-          merge-multiple: true
-
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -403,7 +350,5 @@ jobs:
           files: |
             dist/kubeforward-*-linux-*.tar.gz
             dist/kubeforward-*-linux-*.tar.gz.sha256
-            dist/kubeforward-*-windows-*.zip
-            dist/kubeforward-*-windows-*.zip.sha256
             dist/kubeforward-*-darwin-*.zip
             dist/kubeforward-*-darwin-*.zip.sha256


### PR DESCRIPTION
## Highlights

- remove Windows targets from the release build matrix
- drop Windows artifact packaging and publishing steps
- keep Linux and macOS release flow unchanged

## Why

The `0.0.12` release failed because the new runtime foundation compiles POSIX-only code unconditionally, while the workflow still advertised Windows release targets. Until there is a real Windows platform boundary, shipping Windows artifacts is fiction.

## Validation

- checked the failing release run `22810523452` and verified the Windows jobs fail on POSIX headers/APIs
- verified the workflow diff removes downstream Windows artifact references as well, not just the matrix rows
- did not run the full GitHub Actions workflow locally

Refs #15