### PR TITLE
[codex] Bump version to 0.0.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(kubeforward VERSION 0.1.0 LANGUAGES CXX)
+project(kubeforward VERSION 0.0.15 LANGUAGES CXX)
 
 enable_testing()
 
@@ -8,7 +8,11 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(KF_APP_VERSION "0.0.0" CACHE STRING "kubeforward CLI version string")
+if(NOT DEFINED KF_APP_VERSION OR KF_APP_VERSION STREQUAL "0.0.0")
+  set(KF_APP_VERSION "${PROJECT_VERSION}" CACHE STRING "kubeforward CLI version string" FORCE)
+else()
+  set(KF_APP_VERSION "${KF_APP_VERSION}" CACHE STRING "kubeforward CLI version string")
+endif()
 
 find_package(cxxopts CONFIG REQUIRED)
 find_package(yaml-cpp CONFIG REQUIRED)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kubeforward",
-  "version-string": "0.1.0",
+  "version-string": "0.0.15",
   "builtin-baseline": "81ded1ca9f81437a39dc520c653f3006953308f3",
   "dependencies": [
     "catch2",


### PR DESCRIPTION
## Summary

- Bump CMake project metadata from `0.1.0` to `0.0.15`.
- Bump `vcpkg.json` `version-string` to `0.0.15`.
- Make the default local CLI version follow `PROJECT_VERSION` instead of reporting `0.0.0`, while preserving explicit `-DKF_APP_VERSION=<tag>` overrides used by the release workflow.

## Why

The latest released tag is `0.0.14`, but repository metadata had drifted to `0.1.0` and local debug builds reported `0.0.0`. This aligns the repo with the intended next release tag, `0.0.15`.

## Validation

- `make test` passed: 70/70
- `make build` passed
- `build/Debug/kubeforward --version` prints `0.0.15`
- `git diff --check origin/main..HEAD` passed