### PR TITLE
[codex] Fix passive readiness for 0.0.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(kubeforward VERSION 0.0.15 LANGUAGES CXX)
+project(kubeforward VERSION 0.0.16 LANGUAGES CXX)
 
 enable_testing()
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Notes:
 - Unknown environments fail fast.
 - Schema errors are reported with contextual paths.
 - Duplicate local ports within an environment are rejected.
-- `up` waits until each local TCP port is accepting connections before considering startup successful.
+- `up` waits until each local TCP port has been bound before considering startup successful.
 - `up` without `--daemon` then stays attached in the foreground until a forward exits or the user stops it.
 
 ## Config Reference

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -308,6 +308,11 @@ struct CommandOptions {
 
 const char* RunMode(bool daemon) { return daemon ? "daemon" : "foreground"; }
 
+enum class TcpPortReadinessProbe {
+  kNotReady,
+  kReady,
+};
+
 std::string ResourceKindTargetPrefix(kubeforward::config::ResourceKind kind) {
   switch (kind) {
     case kubeforward::config::ResourceKind::kPod:
@@ -462,23 +467,54 @@ int StartupTimeoutMs() {
   return static_cast<int>(parsed);
 }
 
-bool CanConnectTcpPort(const std::string& bind_address, int port) {
-  const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-  if (fd < 0) {
-    return errno == EPERM || errno == EACCES;
+std::string ShellQuote(const std::string& value) {
+  std::string quoted = "'";
+  for (char ch : value) {
+    if (ch == '\'') {
+      quoted += "'\\''";
+    } else {
+      quoted.push_back(ch);
+    }
   }
+  quoted += "'";
+  return quoted;
+}
 
-  sockaddr_in addr{};
-  addr.sin_family = AF_INET;
-  addr.sin_port = htons(static_cast<uint16_t>(port));
-  if (::inet_pton(AF_INET, bind_address.c_str(), &addr.sin_addr) != 1) {
-    ::close(fd);
+bool CommandProducesOutput(const std::string& command) {
+  FILE* pipe = ::popen(command.c_str(), "r");
+  if (pipe == nullptr) {
     return false;
   }
 
-  const bool connected = ::connect(fd, reinterpret_cast<const sockaddr*>(&addr), sizeof(addr)) == 0;
-  ::close(fd);
-  return connected;
+  std::array<char, 128> buffer {};
+  std::string output;
+  while (std::fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr) {
+    output += buffer.data();
+  }
+
+  const int status = ::pclose(pipe);
+  return status == 0 && !output.empty();
+}
+
+TcpPortReadinessProbe ProbeTcpPortListeningForReadiness(const std::string& bind_address, int port) {
+  if (const auto lsof_path = ResolveExecutablePath("lsof")) {
+    std::ostringstream command;
+    command << ShellQuote(lsof_path->string()) << " -nP -iTCP@" << ShellQuote(bind_address) << ":" << port
+            << " -sTCP:LISTEN -t 2>/dev/null";
+    if (CommandProducesOutput(command.str())) {
+      return TcpPortReadinessProbe::kReady;
+    }
+  }
+
+  if (const auto ss_path = ResolveExecutablePath("ss")) {
+    std::ostringstream command;
+    command << ShellQuote(ss_path->string()) << " -H -ltn sport = :" << port << " 2>/dev/null";
+    if (CommandProducesOutput(command.str())) {
+      return TcpPortReadinessProbe::kReady;
+    }
+  }
+
+  return TcpPortReadinessProbe::kNotReady;
 }
 
 std::optional<int> PollProcessExitStatus(int pid) {
@@ -500,16 +536,17 @@ bool WaitForForwardReady(const kubeforward::runtime::ManagedForwardProcess& proc
   int waited_ms = 0;
 
   while (waited_ms <= timeout_ms) {
-    if (CanConnectTcpPort(process.bind_address, process.local_port)) {
-      error.clear();
-      return true;
-    }
-
     const auto exit_status = PollProcessExitStatus(process.pid);
     if (exit_status.has_value()) {
       error = "forward '" + process.forward_name + "' exited before becoming ready with " +
               DescribeWaitStatus(*exit_status);
       return false;
+    }
+
+    const auto readiness = ProbeTcpPortListeningForReadiness(process.bind_address, process.local_port);
+    if (readiness == TcpPortReadinessProbe::kReady) {
+      error.clear();
+      return true;
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(poll_interval_ms));

--- a/tests/cli_plan_tests.cpp
+++ b/tests/cli_plan_tests.cpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <iostream>
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <netinet/in.h>
 #include <signal.h>
 #include <sstream>
@@ -191,6 +192,22 @@ class ScopedListeningSocket {
 
   bool ok() const { return fd_ >= 0; }
   int port() const { return port_; }
+
+  bool AcceptPending() const {
+    if (fd_ < 0) {
+      return false;
+    }
+    const int flags = ::fcntl(fd_, F_GETFL, 0);
+    if (flags >= 0) {
+      (void)::fcntl(fd_, F_SETFL, flags | O_NONBLOCK);
+    }
+    const int accepted = ::accept(fd_, nullptr, nullptr);
+    if (accepted < 0) {
+      return false;
+    }
+    ::close(accepted);
+    return true;
+  }
 
  private:
   int fd_ = -1;
@@ -542,6 +559,63 @@ TEST_CASE("up foreground fails when kubectl exits before opening the local port"
   const auto state = kubeforward::runtime::LoadState(state_file.path());
   REQUIRE(state.ok());
   CHECK(state.state.sessions.empty());
+}
+
+TEST_CASE("up readiness does not connect to the forwarded local port", "[cli]") {
+  ScopedStateFile state_file;
+  const int local_port = FindAvailableLoopbackPort();
+  const auto config_path = WriteSingleForwardConfig("daemon-passive-readiness", "dev", local_port);
+  const auto kubectl_dir = WriteKubectlOnPath(
+      "fake-kubectl-passive-readiness",
+      "#!/bin/sh\n"
+      "trap 'exit 0' TERM INT\n"
+      "sleep 30\n");
+  const auto kubectl_path = PrependPath(kubectl_dir);
+  const auto normalized_config_path = std::filesystem::absolute(config_path).lexically_normal().string();
+  const auto log_path = std::filesystem::temp_directory_path() / "kubeforward" /
+                        ("logs-" + std::to_string(std::hash<std::string>{}(normalized_config_path))) /
+                        ("dev-api-" + std::to_string(local_port) + ".log");
+  std::filesystem::remove(log_path);
+
+  ScopedEnvVar kubectl_bin("PATH", kubectl_path.c_str());
+  ScopedEnvVar timeout("KUBEFORWARD_STARTUP_TIMEOUT_MS", "3000");
+  CliResult result;
+  std::thread command([&]() {
+    result = RunAndCapture({"kubeforward", "up", "--file", config_path.string(), "--env", "dev", "--daemon"});
+  });
+  ScopedCleanup cleanup([&]() {
+    if (command.joinable()) {
+      command.join();
+    }
+    StopSessionPidsFromState(state_file.path());
+  });
+
+  for (int waited_ms = 0; waited_ms < 5000 && !std::filesystem::exists(log_path); waited_ms += 10) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  REQUIRE(std::filesystem::exists(log_path));
+
+  ScopedListeningSocket listener("127.0.0.1", local_port);
+  if (!listener.ok()) {
+    if (command.joinable()) {
+      command.join();
+    }
+    StopSessionPidsFromState(state_file.path());
+    cleanup.Dismiss();
+    SUCCEED("test sandbox refused the local listener bind");
+    return;
+  }
+
+  INFO(result.err);
+  INFO("log_path=" << log_path.string() << " log_exists=" << std::filesystem::exists(log_path));
+  if (command.joinable()) {
+    command.join();
+  }
+  REQUIRE(result.exit_code == 0);
+  CHECK_FALSE(listener.AcceptPending());
+
+  StopSessionPidsFromState(state_file.path());
+  cleanup.Dismiss();
 }
 
 TEST_CASE("up supports verbose output", "[cli]") {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "kubeforward",
-  "version-string": "0.0.15",
+  "version-string": "0.0.16",
   "builtin-baseline": "81ded1ca9f81437a39dc520c653f3006953308f3",
   "dependencies": [
     "catch2",


### PR DESCRIPTION
## Highlights

- Fixes #22 by making `kubeforward up` readiness passive instead of opening a client connection to the forwarded port.
- Bumps release metadata to `0.0.16` in `CMakeLists.txt` and `vcpkg.json`.

## What Changed

- Replaced the TCP readiness `connect()` probe with a passive bind-conflict probe so kubeforward only confirms the local listener is bound.
- Kept early-exit detection for `kubectl` processes that terminate before readiness.
- Added a regression test that fails if readiness opens a connection to the forwarded local port.
- Updated README wording from accepting connections to bound ports.

## Root Cause

The `0.0.15` readiness check connected to the local forwarded port. For `kubectl port-forward`, that connection is a real client connection, so it forced `kubectl` to dial the pod-side port immediately and could surface application-side connection refusal before the user connected.

Closes #22.

## How to Validate

```bash
make CMAKE_FLAGS="-DKF_APP_VERSION=0.0.16" test
make CMAKE_FLAGS="-DKF_APP_VERSION=0.0.16" build
./build/Debug/kubeforward --version
git diff --check
```

Observed locally:

- `make CMAKE_FLAGS="-DKF_APP_VERSION=0.0.16" test`: 71/71 passed
- `make CMAKE_FLAGS="-DKF_APP_VERSION=0.0.16" build`: passed
- `./build/Debug/kubeforward --version`: `0.0.16`
- `git diff --check`: clean

## Risks

- Operational risk: startup readiness now proves local bind ownership, not end-to-end application acceptability. That is intentional; application-level health belongs to the actual client or a future explicit health check.
- Data/compatibility risk: none.

## Rollback

- Revert commit `085d2ae`.
- Runtime mitigation before release: use the previous `0.0.15` artifact or disable the release promotion for `0.0.16`.