### PR TITLE
feat(config): add resource-level context overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Notes:
 - Unknown environments fail fast.
 - Schema errors are reported with contextual paths.
 - Duplicate local ports within an environment are rejected.
+- Set `resource.context` for per-forward Kubernetes contexts; environment/default `context` still works as a deprecated fallback and is overridden by `resource.context`.
 - `up` waits until each local TCP port has been bound before considering startup successful.
 - `up` without `--daemon` then stays attached in the foreground until a forward exits or the user stops it.
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -22,6 +22,7 @@ environments:
     extends: string?             # optional parent env for DTAPS reuse
     description: string?
     kubeconfig/context/namespace/bindAddress/labels: overrides
+    # context here is deprecated; prefer resource.context below.
     guards:
       allowProduction: bool?     # explicit opt-in for prod usage
     forwards:
@@ -29,6 +30,7 @@ environments:
         resource:
           kind: enum[pod, deployment, service, statefulset]
           name: string                      # required concrete target name
+          context: string?                  # overrides env/default kubectl context
           namespace: string?                # overrides env/default namespace
         ports:
           - local: int (required, 1-65535)
@@ -47,8 +49,9 @@ environments:
 ## Resolution & Overrides
 1. `defaults` apply to every environment unless explicitly overridden.
 2. `extends` performs a shallow merge (metadata excluded). Lists are replaced, not merged, to keep order deterministic.
-3. Namespace resolution order: port-forward namespace → environment namespace → defaults namespace → error if unset.
-4. Local port collisions are forbidden post-merge. When duplicates appear, validation fails with both forward names and env.
+3. Context resolution order: `resource.context` → environment/default `context` → no `--context` flag. Environment/default context remains supported as a deprecated fallback for existing configs.
+4. Namespace resolution order: port-forward namespace → environment namespace → defaults namespace → error if unset.
+5. Local port collisions are forbidden post-merge. When duplicates appear, validation fails with both forward names and env.
 
 ## Validation Rules
 - Unknown keys anywhere cause failure; no silent drops.

--- a/include/kubeforward/config/types.h
+++ b/include/kubeforward/config/types.h
@@ -34,6 +34,10 @@ struct Metadata {
 };
 
 /// Default target settings inherited by environments and forwards.
+///
+/// `context` is retained as a deprecated fallback. Prefer setting
+/// ResourceSelector::context on each forward resource when configs need to span
+/// multiple Kubernetes contexts.
 struct TargetDefaults {
   std::optional<std::string> kubeconfig;
   std::optional<std::string> context;
@@ -51,6 +55,7 @@ struct EnvironmentGuards {
 struct ResourceSelector {
   ResourceKind kind = ResourceKind::kPod;
   std::optional<std::string> name;
+  std::optional<std::string> context;
   std::optional<std::string> namespace_override;
 };
 

--- a/include/kubeforward/runtime/resolved_plan.h
+++ b/include/kubeforward/runtime/resolved_plan.h
@@ -15,6 +15,7 @@ struct ResolvedForward {
   std::string name;
   config::ResourceSelector resource;
   std::vector<config::PortMapping> ports;
+  std::optional<std::string> context;
   std::string namespace_name;
   bool detach = false;
   config::RestartPolicy restart_policy = config::RestartPolicy::kFailFast;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -196,6 +196,7 @@ void PrintPlanVerbose(const std::string& name, const kubeforward::config::Enviro
     std::cout << "      resource:\n";
     std::cout << "        kind: " << ResourceKindToString(forward.resource.kind) << "\n";
     std::cout << "        name: " << OptionalValueOr(forward.resource.name) << "\n";
+    std::cout << "        context: " << OptionalValueOr(forward.resource.context) << "\n";
     std::cout << "        namespace: " << OptionalValueOr(forward.resource.namespace_override) << "\n";
     std::cout << "      annotations:\n";
     std::cout << "        detach: " << (forward.detach ? "true" : "false") << "\n";
@@ -259,6 +260,7 @@ void PrintPlanVerbose(const kubeforward::config::EnvironmentDefinition& source_e
     std::cout << "      resource:\n";
     std::cout << "        kind: " << ResourceKindToString(forward.resource.kind) << "\n";
     std::cout << "        name: " << OptionalValueOr(forward.resource.name) << "\n";
+    std::cout << "        context: " << OptionalValueOr(forward.context) << "\n";
     std::cout << "        namespace: " << OptionalValueOr(forward.resource.namespace_override) << "\n";
     std::cout << "      annotations:\n";
     std::cout << "        detach: " << (forward.detach ? "true" : "false") << "\n";
@@ -606,9 +608,9 @@ bool BuildKubectlPortForwardArgv(const kubeforward::runtime::ResolvedEnvironment
   argv = {KubectlBinary(), "port-forward", target, std::to_string(port.local_port) + ":" + std::to_string(port.remote_port)};
   argv.push_back("--namespace");
   argv.push_back(forward.namespace_name);
-  if (env.settings.context.has_value() && !env.settings.context->empty()) {
+  if (forward.context.has_value() && !forward.context->empty()) {
     argv.push_back("--context");
-    argv.push_back(*env.settings.context);
+    argv.push_back(*forward.context);
   }
   if (env.settings.kubeconfig.has_value() && !env.settings.kubeconfig->empty()) {
     argv.push_back("--kubeconfig");

--- a/src/config/loader.cpp
+++ b/src/config/loader.cpp
@@ -332,7 +332,7 @@ ResourceSelector ParseResourceSelector(const YAML::Node& node, const std::string
     return selector;
   }
   EnsureAllowedKeys(node, context,
-                    MakeSet(std::vector<std::string>{"kind", "name", "namespace"}), errors);
+                    MakeSet(std::vector<std::string>{"kind", "name", "context", "namespace"}), errors);
   if (const auto kind_value = ReadOptionalString(node["kind"], context + ".kind", errors)) {
     selector.kind = ParseResourceKind(*kind_value, context + ".kind", errors);
   } else {
@@ -345,6 +345,9 @@ ResourceSelector ParseResourceSelector(const YAML::Node& node, const std::string
   }
   if (!selector.name.has_value()) {
     AddError(errors, context + ".name", "resource name is required");
+  }
+  if (const auto ctx = ReadOptionalString(node["context"], context + ".context", errors)) {
+    selector.context = ctx;
   }
   if (const auto ns = ReadOptionalString(node["namespace"], context + ".namespace", errors)) {
     selector.namespace_override = ns;

--- a/src/runtime/resolved_plan.cpp
+++ b/src/runtime/resolved_plan.cpp
@@ -70,6 +70,7 @@ std::vector<ResolvedForward> ResolveForwards(const std::string& env_name,
     forward.health_check = source.health_check;
     forward.env = source.env;
     forward.annotations = source.annotations;
+    forward.context = source.resource.context.has_value() ? source.resource.context : settings.context;
 
     const std::string namespace_name = source.resource.namespace_override.has_value()
                                            ? *source.resource.namespace_override

--- a/tests/cli_plan_tests.cpp
+++ b/tests/cli_plan_tests.cpp
@@ -394,6 +394,15 @@ int FindAvailableLoopbackPort() {
   return RandomLocalPort();
 }
 
+bool ContainsAdjacentArgs(const std::vector<std::string>& argv, const std::string& flag, const std::string& value) {
+  for (size_t i = 0; i + 1 < argv.size(); ++i) {
+    if (argv[i] == flag && argv[i + 1] == value) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool CanConnectTcpPort(int port, const std::string& bind_address = "127.0.0.1") {
   const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
   if (fd < 0) {
@@ -525,6 +534,20 @@ TEST_CASE("up supports daemon mode and explicit environment", "[cli]") {
   REQUIRE(result.exit_code == 0);
   CHECK(result.out.find("env: dev") != std::string::npos);
   CHECK(result.out.find("mode: daemon") != std::string::npos);
+}
+
+TEST_CASE("up uses environment context as default and resource context as override", "[cli]") {
+  ScopedEnvVar noop_runner("KUBEFORWARD_USE_NOOP_RUNNER", "1");
+  ScopedStateFile state_file;
+  const auto result = RunAndCapture({"kubeforward", "up", "--file", Fixture("resource_contexts.yaml"), "--env", "dev"});
+
+  REQUIRE(result.exit_code == 0);
+  const auto state = kubeforward::runtime::LoadState(state_file.path());
+  REQUIRE(state.ok());
+  REQUIRE(state.state.sessions.size() == 1);
+  REQUIRE(state.state.sessions.at(0).forwards.size() == 2);
+  CHECK(ContainsAdjacentArgs(state.state.sessions.at(0).forwards.at(0).argv, "--context", "env-cluster"));
+  CHECK(ContainsAdjacentArgs(state.state.sessions.at(0).forwards.at(1).argv, "--context", "resource-cluster"));
 }
 
 TEST_CASE("up daemon fails when kubectl exits before opening the local port", "[cli]") {

--- a/tests/config_loader_tests.cpp
+++ b/tests/config_loader_tests.cpp
@@ -125,3 +125,17 @@ TEST_CASE("config rejects selector-based resources", "[config]") {
   }
   REQUIRE(saw_selector_error);
 }
+
+TEST_CASE("config accepts resource-level context", "[config]") {
+  const auto result = kubeforward::config::LoadConfigFromFile(Fixture("resource_contexts.yaml"));
+  REQUIRE(result.ok());
+  REQUIRE(result.config);
+
+  const auto& dev = result.config->environments.at("dev");
+  REQUIRE(dev.settings.context.has_value());
+  CHECK(dev.settings.context.value() == "env-cluster");
+  REQUIRE(dev.forwards.size() == 2);
+  CHECK_FALSE(dev.forwards.at(0).resource.context.has_value());
+  REQUIRE(dev.forwards.at(1).resource.context.has_value());
+  CHECK(dev.forwards.at(1).resource.context.value() == "resource-cluster");
+}

--- a/tests/fixtures/resource_contexts.yaml
+++ b/tests/fixtures/resource_contexts.yaml
@@ -1,0 +1,26 @@
+version: 1
+metadata:
+  project: demo-project
+defaults:
+  namespace: default
+  bindAddress: 127.0.0.1
+environments:
+  dev:
+    description: Multi-cluster development environment
+    context: env-cluster
+    forwards:
+      - name: api
+        resource:
+          kind: deployment
+          name: api
+        ports:
+          - local: 7000
+            remote: 80
+      - name: worker
+        resource:
+          kind: service
+          name: worker
+          context: resource-cluster
+        ports:
+          - local: 7001
+            remote: 80

--- a/tests/runtime_resolved_plan_tests.cpp
+++ b/tests/runtime_resolved_plan_tests.cpp
@@ -95,3 +95,22 @@ TEST_CASE("resolved plan rejects inherited non-detached production forwards", "[
   REQUIRE_FALSE(plan_result.errors.empty());
   CHECK(plan_result.errors.front().message == "production environment requires detach=true for every forward");
 }
+
+TEST_CASE("resolved plan applies environment context and resource overrides", "[runtime]") {
+  const auto load_result = kubeforward::config::LoadConfigFromFile(Fixture("resource_contexts.yaml"));
+  REQUIRE(load_result.ok());
+  REQUIRE(load_result.config.has_value());
+
+  const auto plan_result = kubeforward::runtime::BuildResolvedPlan(
+      *load_result.config, Fixture("resource_contexts.yaml"), std::optional<std::string>{"dev"});
+  REQUIRE(plan_result.ok());
+  REQUIRE(plan_result.plan.has_value());
+  REQUIRE(plan_result.plan->environments.size() == 1);
+
+  const auto& env = plan_result.plan->environments.at(0);
+  REQUIRE(env.forwards.size() == 2);
+  REQUIRE(env.forwards.at(0).context.has_value());
+  CHECK(env.forwards.at(0).context.value() == "env-cluster");
+  REQUIRE(env.forwards.at(1).context.has_value());
+  CHECK(env.forwards.at(1).context.value() == "resource-cluster");
+}


### PR DESCRIPTION
## Summary

- add `resource.context` so a single environment can forward resources from multiple Kubernetes contexts
- keep environment/default `context` as a deprecated fallback for existing configs
- make `resource.context` override the inherited environment/default context when both are set
- update docs and cover the resolved argv behavior in tests

## Why

This keeps the schema additive for existing users while allowing mixed-cluster forward sets in one environment.

Closes #26

## Validation

- `VCPKG_ROOT=<vcpkg-root> make test TEST_TARGET=kubeforward_tests`
- `./build/Debug/kubeforward plan --file tests/fixtures/resource_contexts.yaml --env dev --verbose`
